### PR TITLE
Add `BoundEvent`, `ObjEvent`, and `ModelEvent` to `__all__` in `blocks.__init__` (fix #4)

### DIFF
--- a/src/cpsat_logutils/blocks/__init__.py
+++ b/src/cpsat_logutils/blocks/__init__.py
@@ -2,7 +2,7 @@
 This folder contains the logic for parsing individual blocks from the log.
 """
 
-from .search_progress import SearchProgressBlock
+from .search_progress import SearchProgressBlock, BoundEvent, ObjEvent, ModelEvent
 from .search_stats import SearchStatsBlock
 from .lns_stats import LnsStatsBlock
 from .solution_repositories import SolutionRepositoriesBlock
@@ -84,4 +84,7 @@ __all__ = [
     "SequentialSearchProgressBlock",
     "TableBlock",
     "LogBlock",
+    "BoundEvent", 
+    "ObjEvent", 
+    "ModelEvent",
 ]


### PR DESCRIPTION
**Description**
This pull request fixes #4 by adding the missing `BoundEvent`, `ObjEvent`, and `ModelEvent` classes to `__all__` in `cpsat_logutils.blocks.__init__.py`.
I am not sure what the intended sorting rule for `__all__` is, so I simply appended these new items at the end, keeping the same order as they appear in the current source code.

**Motivation**
This change allows library users to import these classes directly from `cpsat_logutils.blocks`, and to check event types in a cleaner and more explicit way (e.g. `isinstance(e, BoundEvent)`) instead of relying on type name strings.

**Changes**

* Added `BoundEvent`, `ObjEvent`, and `ModelEvent` to `__all__` in `cpsat_logutils.blocks.__init__.py`.

**Impact**
No breaking changes. Only improves import ergonomics for developers working with search progress events.